### PR TITLE
Fixes #25534 - Do not include :ssh_key_file in ssh_params

### DIFF
--- a/app/models/ssh_execution_provider.rb
+++ b/app/models/ssh_execution_provider.rb
@@ -34,8 +34,7 @@ class SSHExecutionProvider < RemoteExecutionProvider
         :ssh_user => ssh_user(host),
         :ssh_port => ssh_port(host),
         :ssh_password => ssh_password(host),
-        :ssh_key_passphrase => ssh_key_passphrase(host),
-        :ssh_key_file => File.expand_path(ForemanRemoteExecutionCore.settings.fetch(:ssh_identity_key_file))
+        :ssh_key_passphrase => ssh_key_passphrase(host)
       }
     end
 


### PR DESCRIPTION
The location of the key file is a per-proxy configuration setting, and
can not be a parameter of the /ssh/session API of the proxy.